### PR TITLE
Get token from API

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,12 +5,6 @@
     "default": "rarbg-addon-4k",
     "required": true
   },
-  "token": {
-    "title": "Token",
-    "type": "string",
-    "default": "834mdti512",
-    "required": true
-  },
   "minSeeders": {
     "title": "Min. amount of seeders",
     "type": "number",

--- a/torrentapi.js
+++ b/torrentapi.js
@@ -1,10 +1,28 @@
 const request = require('request');
-const {config} = require('internal');
+const { config, persist } = require('internal');
+
+let token = persist.token || ''
+
+request({
+    uri: 'https://torrentapi.org/pubapi_v2.php',
+    qs: { get_token: 'get_token', app_id: config.appId },
+    json: true,
+    headers: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:67.0) Gecko/20100101 Firefox/67.0'
+    }
+}, (error, response, body) => {
+    if ((body || {}).token) {
+        console.log('RARBG 4k: Successfully fetched API token')
+        token = body.token
+    } else
+        console.log('RARBG 4k: ' + ((error || {}).message || 'Unknown error while fetching API token'))
+});
+
 
 class TorrentApi {
     queryAPI(mode, params = {}, format = 'json_extended') {
         params.app_id = config.appId;
-        params.token = config.token;
+        params.token = token;
         params.sort = config.sortingMethod;
         params.min_seeders = config.minSeeders;
         params.mode = mode;


### PR DESCRIPTION
Hi, I believe this add-on is broken without the changes in this PR. The token shouldn't be configurable by the user, it needs to be gotten from the API based on just `app_id`.

For me, I tried 3 different `app_id`'s, and they all result in the same `token`, which is different from the default `token` set in the config. Also, the default `app_id` ("rarbg-addon-4k"), always gives me a `429 Too Many Requests` error, even when I first tried the add-on.. Not sure what we can do about that, but GitHub is full of `app_id`'s for this API. 😛 